### PR TITLE
Mapped search by coursid to course details page

### DIFF
--- a/ratenyu/search/search_util.py
+++ b/ratenyu/search/search_util.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from courses.models import Course, Class, Review
 from professors.models import Professor
 from courses.course_util import *
+import re
 
 
 def course_query(query: str) -> Class:
@@ -24,8 +25,17 @@ def professor_query(query: str) -> Class:
     return professors
 
 
+def course_id_query(course_subject_code: str, catalog_number: str) -> Class:
+    course = Course.objects.get(
+        course_subject_code=course_subject_code.upper(),
+        catalog_number=catalog_number.upper(),
+    )
+    return course
+
 # this returns a dictionary that contains the
 # info necessary to display a course on course results page
+
+
 def get_course_results_info(course: Class) -> dict:
     classes = Class.objects.filter(course=course.course_id)
     reviews_list = create_review_objects(classes)
@@ -35,3 +45,12 @@ def get_course_results_info(course: Class) -> dict:
         "reviews_list": reviews_list,
         "reviews_avg": reviews_avg,
     }
+
+
+def get_sub_code_and_cat_num(query: str) -> tuple:
+    course_subject_code = re.search(
+        r'^[a-zA-Z]+[-\s][a-zA-Z]{2}', query).group(0)
+    if '-' not in course_subject_code:
+        course_subject_code = course_subject_code.replace(' ', '-')
+    catalog_number = re.search(r'[0-9]{4}', query).group(0)
+    return course_subject_code, catalog_number

--- a/ratenyu/search/templates/search/index.html
+++ b/ratenyu/search/templates/search/index.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 
-    <h1 class="welcome">Welcome to RateNYU!</h1>
-    <h2 class="welcome">Search for reviews by course name, course id, or professor name.</h2>
+<h1 class="welcome">Welcome to RateNYU!</h1>
+<h2 class="welcome">Search for reviews by course name, course id, or professor name.</h2>
 
-    <div class="searchbar">
+<div class="searchbar">
     <form class="search" method="GET" action="search">
         <select class="dropdown" name="search_by">
             <option value="CourseID">Course ID</option>
@@ -14,9 +14,9 @@
         <input type="text" class="search" name="query" placeholder="Start Typing">
         <button type="submit" class="search">Search!</button>
     </form>
-    </div>
+</div>
 
-    <div class="nyu-logo">
-    </div>
+<div class="nyu-logo">
+</div>
 
 {% endblock %}

--- a/ratenyu/search/urls.py
+++ b/ratenyu/search/urls.py
@@ -4,10 +4,6 @@ from . import views
 
 app_name = "search"
 urlpatterns = [
-    path('', views.index, name='index'),
-    path('<str:professor_name>/professor_result',
-         views.professor_result, name='professor_result'),
-    path('<str:course_name>/course_result',
-         views.course_result, name='course_result'),
-    path('search_by_id', views.search_by_id_func, name='search_by_id'),
+    path("", views.index, name="index"),
+    path("search", views.search_by_select, name="search_by_select"),
 ]

--- a/ratenyu/search/urls.py
+++ b/ratenyu/search/urls.py
@@ -4,6 +4,10 @@ from . import views
 
 app_name = "search"
 urlpatterns = [
-    path("", views.index, name="index"),
-    path("search", views.search_by_select, name="search_by_select"),
+    path('', views.index, name='index'),
+    path('<str:professor_name>/professor_result',
+         views.professor_result, name='professor_result'),
+    path('<str:course_name>/course_result',
+         views.course_result, name='course_result'),
+    path('search_by_id', views.search_by_id_func, name='search_by_id'),
 ]

--- a/ratenyu/search/views.py
+++ b/ratenyu/search/views.py
@@ -1,3 +1,5 @@
+import re
+from django.http import HttpRequest, Http404
 from django.shortcuts import render
 from django.http import HttpRequest, Http404
 from django.db.models import Q
@@ -5,6 +7,7 @@ from courses.models import Course, Class, Review
 from professors.models import Professor
 from .search_util import *
 from courses.course_util import *
+from courses.views import course_detail
 
 
 def index(request):
@@ -53,5 +56,73 @@ def search_by_professor_name(request):
         )
         context = {"professors": professors}
         return render(request, "search/professorResult.html", context)
+    except:
+        raise Http404("Something went wrong")
+
+
+'''
+This function is used in the search page.
+A user can search course by id, professor name, or course name.
+This function will redirect the search result to the corresponding page.
+'''
+
+
+def search_by_id_func(request: HttpRequest):
+    try:
+        search_by = request.GET['search_by']
+        query = request.GET['query']
+        print(search_by)
+        print(query)
+        if search_by == 'CourseID':
+            try:
+                course_subject_code = re.search(
+                    r'^[a-zA-Z]{4}|^[a-zA-Z]{2}[-\s][a-zA-Z]{2}', query).group(0)
+                if len(course_subject_code) == 4:
+                    course_subject_code = course_subject_code[:2] + \
+                        '-' + course_subject_code[2:]
+                elif len(course_subject_code) == 5 and course_subject_code[2] == ' ':
+                    course_subject_code = course_subject_code[:2] + \
+                        '-' + course_subject_code[2:]
+                catalog_number = re.search(r'[0-9]{4}', query).group(0)
+                course_id = Course.objects.get(
+                    course_subject_code=course_subject_code, catalog_number=catalog_number)
+                return course_detail(request, course_id.course_id)
+            except:
+                raise Http404("Invalid Course ID")
+        return render(request, "search/courseResult.html")
+    except:
+        raise Http404("Something went wrong")
+
+
+'''
+This function is used in the search page.
+A user can search course by id, professor name, or course name.
+This function will redirect the search result to the corresponding page.
+'''
+
+
+def search_by_id_func(request: HttpRequest):
+    try:
+        search_by = request.GET['search_by']
+        query = request.GET['query']
+        print(search_by)
+        print(query)
+        if search_by == 'CourseID':
+            try:
+                course_subject_code = re.search(
+                    r'^[a-zA-Z]{4}|^[a-zA-Z]{2}[-\s][a-zA-Z]{2}', query).group(0)
+                if len(course_subject_code) == 4:
+                    course_subject_code = course_subject_code[:2] + \
+                        '-' + course_subject_code[2:]
+                elif len(course_subject_code) == 5 and course_subject_code[2] == ' ':
+                    course_subject_code = course_subject_code[:2] + \
+                        '-' + course_subject_code[2:]
+                catalog_number = re.search(r'[0-9]{4}', query).group(0)
+                course_id = Course.objects.get(
+                    course_subject_code=course_subject_code, catalog_number=catalog_number)
+                return course_detail(request, course_id.course_id)
+            except:
+                raise Http404("Invalid Course ID")
+        return render(request, "search/courseResult.html")
     except:
         raise Http404("Something went wrong")

--- a/ratenyu/search/views.py
+++ b/ratenyu/search/views.py
@@ -108,16 +108,12 @@ def search_by_id_func(request: HttpRequest):
         if search_by == 'CourseID':
             try:
                 course_subject_code = re.search(
-                    r'^[a-zA-Z]{4}|^[a-zA-Z]{2}[-\s][a-zA-Z]{2}', query).group(0)
-                if len(course_subject_code) == 4:
-                    course_subject_code = course_subject_code[:2] + \
-                        '-' + course_subject_code[2:]
-                elif len(course_subject_code) == 5 and course_subject_code[2] == ' ':
-                    course_subject_code = course_subject_code[:2] + \
-                        '-' + course_subject_code[3:]
+                    r'^[a-zA-Z]+[-\s][a-zA-Z]{2}', query).group(0)
+                if '-' not in course_subject_code:
+                    course_subject_code = course_subject_code.replace(' ', '-')
                 catalog_number = re.search(r'[0-9]{4}', query).group(0)
                 course_id = Course.objects.get(
-                    course_subject_code=course_subject_code, catalog_number=catalog_number)
+                    course_subject_code=course_subject_code.upper(), catalog_number=catalog_number)
                 return course_detail(request, course_id.course_id)
             except:
                 raise Http404("Invalid Course ID")

--- a/ratenyu/search/views.py
+++ b/ratenyu/search/views.py
@@ -114,7 +114,7 @@ def search_by_id_func(request: HttpRequest):
                         '-' + course_subject_code[2:]
                 elif len(course_subject_code) == 5 and course_subject_code[2] == ' ':
                     course_subject_code = course_subject_code[:2] + \
-                        '-' + course_subject_code[2:]
+                        '-' + course_subject_code[3:]
                 catalog_number = re.search(r'[0-9]{4}', query).group(0)
                 course_id = Course.objects.get(
                     course_subject_code=course_subject_code, catalog_number=catalog_number)

--- a/ratenyu/search/views.py
+++ b/ratenyu/search/views.py
@@ -1,9 +1,7 @@
-import re
 from django.http import HttpRequest, Http404
 from django.shortcuts import render
 from django.http import HttpRequest, Http404
 from django.db.models import Q
-from courses.models import Course, Class, Review
 from professors.models import Professor
 from .search_util import *
 from courses.course_util import *
@@ -24,8 +22,14 @@ def search_by_select(request: HttpRequest):
         return search_by_professor_name(request)
 
 
-def search_by_course_id(request: HttpRequest):
-    return render(request, "search/courseResult.html")
+def search_by_course_id(request: HttpRequest) -> render:
+    try:
+        query = request.GET["query"].strip()
+        course_subject_code, catalog_number = get_sub_code_and_cat_num(query)
+        course_id = course_id_query(course_subject_code, catalog_number)
+        return course_detail(request, course_id.course_id)
+    except:
+        raise Http404("Something went wrong")
 
 
 def search_by_course_name(request: HttpRequest):
@@ -56,67 +60,5 @@ def search_by_professor_name(request):
         )
         context = {"professors": professors}
         return render(request, "search/professorResult.html", context)
-    except:
-        raise Http404("Something went wrong")
-
-
-'''
-This function is used in the search page.
-A user can search course by id, professor name, or course name.
-This function will redirect the search result to the corresponding page.
-'''
-
-
-def search_by_id_func(request: HttpRequest):
-    try:
-        search_by = request.GET['search_by']
-        query = request.GET['query']
-        print(search_by)
-        print(query)
-        if search_by == 'CourseID':
-            try:
-                course_subject_code = re.search(
-                    r'^[a-zA-Z]{4}|^[a-zA-Z]{2}[-\s][a-zA-Z]{2}', query).group(0)
-                if len(course_subject_code) == 4:
-                    course_subject_code = course_subject_code[:2] + \
-                        '-' + course_subject_code[2:]
-                elif len(course_subject_code) == 5 and course_subject_code[2] == ' ':
-                    course_subject_code = course_subject_code[:2] + \
-                        '-' + course_subject_code[2:]
-                catalog_number = re.search(r'[0-9]{4}', query).group(0)
-                course_id = Course.objects.get(
-                    course_subject_code=course_subject_code, catalog_number=catalog_number)
-                return course_detail(request, course_id.course_id)
-            except:
-                raise Http404("Invalid Course ID")
-        return render(request, "search/courseResult.html")
-    except:
-        raise Http404("Something went wrong")
-
-
-'''
-This function is used in the search page.
-A user can search course by id, professor name, or course name.
-This function will redirect the search result to the corresponding page.
-'''
-
-
-def search_by_id_func(request: HttpRequest):
-    try:
-        search_by = request.GET['search_by']
-        query = request.GET['query']
-        if search_by == 'CourseID':
-            try:
-                course_subject_code = re.search(
-                    r'^[a-zA-Z]+[-\s][a-zA-Z]{2}', query).group(0)
-                if '-' not in course_subject_code:
-                    course_subject_code = course_subject_code.replace(' ', '-')
-                catalog_number = re.search(r'[0-9]{4}', query).group(0)
-                course_id = Course.objects.get(
-                    course_subject_code=course_subject_code.upper(), catalog_number=catalog_number)
-                return course_detail(request, course_id.course_id)
-            except:
-                raise Http404("Invalid Course ID")
-        return render(request, "search/courseResult.html")
     except:
         raise Http404("Something went wrong")

--- a/ratenyu/search/views.py
+++ b/ratenyu/search/views.py
@@ -105,8 +105,6 @@ def search_by_id_func(request: HttpRequest):
     try:
         search_by = request.GET['search_by']
         query = request.GET['query']
-        print(search_by)
-        print(query)
         if search_by == 'CourseID':
             try:
                 course_subject_code = re.search(


### PR DESCRIPTION
When a user searches course id, the search page redirects to course details page.
Course id can be searched by:
1. BT GY 6093
2. BT-GY 6093
3. BT GY 6093 (Anything in between)
4. BT GY 6093 121212 (It will take the first 4 digits in the string)
Rest all will give error.  Will fix the 4th point in the future

There are tab changes in html file in addition to my change because VScode is changing the format on saving the file. I will look into suppressing that change in the future. 
 