### PR TITLE
Revert eb commands

### DIFF
--- a/.ebextensions/django_dev.config
+++ b/.ebextensions/django_dev.config
@@ -18,20 +18,14 @@ container_commands:
   04_migrate:
     command: "source /var/app/venv/*/bin/activate && python3 ratenyu/manage.py migrate --noinput"
     leader_only: true
-  05_makemigrations_empty:
-    command: "source /var/app/venv/*/bin/activate && python3 ratenyu/manage.py makemigrations --empty courses --noinput"
-    leader_only: true
-  06_migrate:
-    command: "source /var/app/venv/*/bin/activate && python3 ratenyu/manage.py migrate --noinput"
-    leader_only: true
-  07_createsu:
+  05_createsu:
     command: "source /var/app/venv/*/bin/activate && python3 ratenyu/manage.py createsu"
     leader_only: true
-  08_collectstatic:
+  06_collectstatic:
     command: "source /var/app/venv/*/bin/activate && python3 ratenyu/manage.py collectstatic --noinput"
-  09_loaddata:
+  07_loaddata:
     command: "source /var/app/venv/*/bin/activate && python3 ratenyu/manage.py load_data"
-  10_createsite:
+  08_createsite:
     command: "source /var/app/venv/*/bin/activate && python3 ratenyu/manage.py createsite_dev"
-  11_install_spacy:
+  09_install_spacy:
     command: "source /var/app/venv/*/bin/activate && python3 -m spacy download en"


### PR DESCRIPTION
Reverting the extra EB commands we added to empty migrations (while we were debugging the AWS migration issue).
These are no longer needed.