### PR TITLE
Limit reviews

### DIFF
--- a/ratenyu/courses/course_util.py
+++ b/ratenyu/courses/course_util.py
@@ -126,22 +126,24 @@ def add_review_from_details(request) -> tuple:
         try:
             existing_review = Review.objects.filter(user=request.user)
             found_matching = False
-            for er in existing_review:
-                if er.class_id.course_id == course_id:
-                    found_matching = True
-                    break
+            if existing_review:
+                for er in existing_review:
+                    if er.class_id.course_id == course_id:
+                        found_matching = True
+                        break
             if found_matching:
                 return False, DUPLICATE_REVIEW
-            new_review = Review(
-                review_text=review_text,
-                rating=review_rating,
-                class_id=get_class(course_id, professor_name),
-                user=request.user,
-                pub_date=timezone.now(),
-            )
-            new_review.save()
-            LOGGER.debug("Review saved successfully", review_text)
-            return True, REVIEW_ADDED
+            else:
+                new_review = Review(
+                    review_text=review_text,
+                    rating=review_rating,
+                    class_id=get_class(course_id, professor_name),
+                    user=request.user,
+                    pub_date=timezone.now(),
+                )
+                new_review.save()
+                LOGGER.debug("Review saved successfully", review_text)
+                return True, REVIEW_ADDED
         except Exception as e:
             LOGGER.exception(e)
             return False, REVIEW_NOT_SAVED

--- a/ratenyu/courses/course_util.py
+++ b/ratenyu/courses/course_util.py
@@ -66,6 +66,14 @@ def save_new_review(
     )
     course_id = course_id_query(course_subject_code, catalog_number).course_id
     class_obj = get_class(course_id=course_id, professor_name=professor_name)
+    existing_review = Review.objects.filter(user=user)
+    found_matching = False
+    for er in existing_review:
+        if er.class_id.course_id == course_id:
+            found_matching = True
+            break
+    if found_matching:
+        return "Already wrote review for this course"
     new_review = Review(
         review_text=review_text,
         rating=review_rating,

--- a/ratenyu/courses/course_util.py
+++ b/ratenyu/courses/course_util.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger("project")
 REVIEW_ADDED = "Your review was saved!"
 REVIEW_CONTAINS_PROFANITY = "Profane review was not saved!"
 REVIEW_NOT_SAVED = "Uh Oh, something went wrong. Your review could not be saved."
+DUPLICATE_REVIEW = "You already wrote a review for this course."
 
 
 def create_review_objects_from_class(class_obj: Class) -> List[dict]:
@@ -123,6 +124,14 @@ def add_review_from_details(request) -> tuple:
     review_text = request.POST["review_text"]
     if text_is_valid(review_text):
         try:
+            existing_review = Review.objects.filter(user=request.user)
+            found_matching = False
+            for er in existing_review:
+                if er.class_id.course_id == course_id:
+                    found_matching = True
+                    break
+            if found_matching:
+                return False, DUPLICATE_REVIEW
             new_review = Review(
                 review_text=review_text,
                 rating=review_rating,

--- a/ratenyu/courses/tests.py
+++ b/ratenyu/courses/tests.py
@@ -88,6 +88,25 @@ class TestAddReviewPage(TestCase):
             f"Request returned {response.status_code} for request {request_str}",
         )
 
+    def test_limit_1_review(self) -> None:
+        request_str = f"http://127.0.0.1:8000/courses/add_review"
+        request_body = {
+            "add_review_course_id": "TS-UY 1000",
+            "add_review_professor_name": "John Doe",
+            "review_rating": "5",
+            "review_text": "Test Content",
+        }
+        request = self.factory.post(request_str, request_body)
+        request._messages = messages.storage.default_storage(request)
+        request.user = User.objects.get(pk=1)
+        response = add_review(request)
+        response = add_review(request)
+        self.assertEqual(len(Review.objects.all()), 1)
+
+
+
+
+
 
 class TestAddReviewPageHelpers(TestCase):
     def setUp(self) -> None:
@@ -156,8 +175,12 @@ class TestReviewFromDetailsPage(TestCase):
         user_tests.create_test_course()
         user_tests.create_test_professor()
         user_tests.create_test_user()
+        user_tests.create_test_course2()
         user_tests.create_test_class_1(
             course=Course.objects.get(pk="1"), professor=Professor.objects.get(pk="1")
+        )
+        user_tests.create_test_class_2(
+            course=Course.objects.get(pk="2"), professor=Professor.objects.get(pk="1")
         )
         user_tests.create_test_review_1(Class.objects.get(pk="1"), User.objects.get(username="viren"))
         user_tests.create_test_review_2(Class.objects.get(pk="1"), User.objects.get(username="viren"))
@@ -167,12 +190,20 @@ class TestReviewFromDetailsPage(TestCase):
     
     def test_review_from_details_page_1(self):
         self.client.login(username="viren", password="viren")
-        request_str = f"http://127.0.0.1:8000/courses/1"
-        response = self.client.post(request_str, {"course_id":"1","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
+        request_str = f"http://127.0.0.1:8000/courses/2"
+        response = self.client.post(request_str, {"course_id":"2","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "This is a test review")
         self.assertContains(response, "5.0")
         self.assertContains(response, REVIEW_ADDED)
+
+    def test_review_from_details_page_repeat(self):
+        self.client.login(username="viren", password="viren")
+        request_str = f"http://127.0.0.1:8000/courses/2"
+        response = self.client.post(request_str, {"course_id":"2","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
+        response = self.client.post(request_str, {"course_id":"2","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "You already wrote a review for this course.")
 
     def test_review_from_details_page_2(self):
         self.client.login(username="viren", password="viren")
@@ -183,8 +214,8 @@ class TestReviewFromDetailsPage(TestCase):
     
     def test_review_from_details_page_3(self):
         self.client.login(username="viren", password="viren")
-        request_str = f"http://127.0.0.1:8000/courses/1"
-        response = self.client.post(request_str, {"course_id":"1","add_review_professor_name":"Different Professor", "review_text": "This is a test review", "review_rating": "6", "submit":""})
+        request_str = f"http://127.0.0.1:8000/courses/2"
+        response = self.client.post(request_str, {"course_id":"2","add_review_professor_name":"Different Professor", "review_text": "This is a test review", "review_rating": "6", "submit":""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, REVIEW_NOT_SAVED)
 

--- a/ratenyu/courses/views.py
+++ b/ratenyu/courses/views.py
@@ -120,12 +120,19 @@ def add_review(request):
                 review_rating=request.POST["review_rating"],
                 review_text=request.POST["review_text"],
             )
-            LOGGER.info(f"Created new Review: {new_review}")
-            add_redirect_message(
-                request=request,
-                message="Your review was saved!",
-                success=True,
-            )
+            if new_review == "Already wrote review for this course":
+                add_redirect_message(
+                    request=request,
+                    message="You already wrote a review for this course.",
+                    success=False,
+                )
+            else:
+                LOGGER.info(f"Created new Review: {new_review}")
+                add_redirect_message(
+                    request=request,
+                    message="Your review was saved!",
+                    success=True,
+                )
             return redirect("courses:add_review")
         except Exception as e:
             LOGGER.exception(f"Could not create review, encountered error: {e}")

--- a/ratenyu/professors/tests.py
+++ b/ratenyu/professors/tests.py
@@ -35,8 +35,16 @@ class TestReviewFromDetailsPage(TestCase):
         user_tests.create_test_course()
         user_tests.create_test_professor()
         user_tests.create_test_user()
+        user_tests.create_test_course2()
+        user_tests.create_test_course3()
         user_tests.create_test_class_1(
             course=Course.objects.get(pk="1"), professor=Professor.objects.get(pk="1")
+        )
+        user_tests.create_test_class_2(
+            course=Course.objects.get(pk="2"), professor=Professor.objects.get(pk="1")
+        )
+        user_tests.create_test_class_3(
+            course=Course.objects.get(pk="3"), professor=Professor.objects.get(pk="1")
         )
         user_tests.create_test_review_1(Class.objects.get(pk="1"), User.objects.get(username="viren"))
         user_tests.create_test_review_2(Class.objects.get(pk="1"), User.objects.get(username="viren"))
@@ -47,7 +55,7 @@ class TestReviewFromDetailsPage(TestCase):
     def test_review_from_details_page_1(self):
         self.client.login(username="viren", password="viren")
         request_str = f"http://127.0.0.1:8000/professors/1"
-        response = self.client.post(request_str, {"course_id":"1","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
+        response = self.client.post(request_str, {"course_id":"2","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "This is a test review")
         self.assertContains(response, "5.0")
@@ -63,7 +71,7 @@ class TestReviewFromDetailsPage(TestCase):
     def test_review_from_details_page_3(self):
         self.client.login(username="viren", password="viren")
         request_str = f"http://127.0.0.1:8000/professors/1"
-        response = self.client.post(request_str, {"course_id":"1","add_review_professor_name":"Different Professor", "review_text": "This is a test review", "review_rating": "6", "submit":""})
+        response = self.client.post(request_str, {"course_id":"3","add_review_professor_name":"Different Professor", "review_text": "This is a test review", "review_rating": "6", "submit":""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, REVIEW_NOT_SAVED)
 
@@ -77,14 +85,14 @@ class TestReviewFromDetailsPage(TestCase):
     def test_pagination_1(self):
         self.client.login(username="viren", password="viren")
         request_str = f"http://127.0.0.1:8000/professors/1?page=thisIsTheTestForPageNumberNotInt"
-        response = self.client.post(request_str, {"course_id":"1","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
+        response = self.client.post(request_str, {"course_id":"2","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "This is a test review")
 
     def test_pagination_2(self):
         self.client.login(username="viren", password="viren")
         request_str = f"http://127.0.0.1:8000/professors/1?page=999"
-        response = self.client.post(request_str, {"course_id":"1","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
+        response = self.client.post(request_str, {"course_id":"2","add_review_professor_name":"John Doe", "review_text": "This is a test review", "review_rating": "5", "submit":""})
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "This is a test review")
 

--- a/ratenyu/users/tests.py
+++ b/ratenyu/users/tests.py
@@ -189,6 +189,15 @@ def create_test_course2() -> Course:
         course_description="course_description",
     )
 
+def create_test_course3() -> Course:
+    Course.objects.create(
+        course_id="3",
+        course_title="test course",
+        course_subject_code="TS-UY",
+        catalog_number="1003",
+        course_description="course_description",
+    )
+
 
 def create_test_professor() -> Professor:
     Professor.objects.create(
@@ -220,6 +229,19 @@ def create_test_class_1(course: Course, professor: Professor) -> Class:
 def create_test_class_2(course: Course, professor: Professor) -> Class:
     return Class.objects.create(
         class_id="2",
+        professor=professor,
+        course=course,
+        class_type="Test",
+        class_section="2",
+        term="Fall2023",
+        last_offered="Fall2023",
+        location="BK",
+        enroll_capacity=50,
+    )
+
+def create_test_class_3(course: Course, professor: Professor) -> Class:
+    return Class.objects.create(
+        class_id="3",
         professor=professor,
         course=course,
         class_type="Test",

--- a/ratenyu/users/tests.py
+++ b/ratenyu/users/tests.py
@@ -180,6 +180,15 @@ def create_test_course() -> Course:
         course_description="course_description",
     )
 
+def create_test_course2() -> Course:
+    Course.objects.create(
+        course_id="2",
+        course_title="test course",
+        course_subject_code="TS-UY",
+        catalog_number="1002",
+        course_description="course_description",
+    )
+
 
 def create_test_professor() -> Professor:
     Professor.objects.create(


### PR DESCRIPTION
Definition of done:
User can only write 1 review per course. 
If they have not written a review for a particular course, they can write the review. 
If they have already written a review for a particular course, they are blocked from writing an additional review on both the 'add review' page and the add review area of course and professor details. 