### PR TITLE
Removed hardcoded password

### DIFF
--- a/ratenyu/util/management/commands/createsu.py
+++ b/ratenyu/util/management/commands/createsu.py
@@ -1,11 +1,11 @@
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
-
+from decouple import config
 
 class Command(BaseCommand):
     help = "Creates a superuser."
 
     def handle(self, *args, **options):
         if not User.objects.filter(username="admin").exists():
-            User.objects.create_superuser(username="admin", password="rateNYU2022")
+            User.objects.create_superuser(username="admin", password=config("ADMIN_PWD"))
         print("Superuser has been created.")


### PR DESCRIPTION
Definition of done:
The hardcoded password in createsu script should be removed and added to environment variables. 
To run the command in your local setup, you will have to add the following value to the .env file. 
`ADMIN_PWD="<str:password>"`

Note: to test it you will have to delete the existing admin user in your local database. 

I have already added the environment variable in ratenyu-dev and ratenyu environments on EBS. 


